### PR TITLE
Test case for nebula-plugins#14

### DIFF
--- a/src/test/groovy/nebula/plugin/extraconfigurations/ProvidedBasePluginIntegrationTest.groovy
+++ b/src/test/groovy/nebula/plugin/extraconfigurations/ProvidedBasePluginIntegrationTest.groovy
@@ -247,7 +247,7 @@ publishing {
         commonsLang.@conf.text() == 'provided'
     }
 
-    @Ignore("Test case for issue: https://github.com/nebula-plugins/gradle-extra-configurations-plugin/issues/14")
+    @Ignore("https://github.com/nebula-plugins/gradle-extra-configurations-plugin/issues/14")
     def "Transitive dependencies in scope provided are not included in WAR archive"() {
         when:
         helper.addSubproject(


### PR DESCRIPTION
nebula-plugins#14 Transitive dependencies in provided scope should not be included in war archives
