### PR TITLE
Fix optional dependencies when multiple repositories exist for install or uploadArchives

### DIFF
--- a/src/main/groovy/nebula/plugin/extraconfigurations/OptionalBasePlugin.groovy
+++ b/src/main/groovy/nebula/plugin/extraconfigurations/OptionalBasePlugin.groovy
@@ -114,10 +114,10 @@ class OptionalBasePlugin implements Plugin<Project> {
         project.plugins.withType(MavenPlugin) {
             // Requires user definition of Maven installer/deployer which could be anywhere in the build script
             project.afterEvaluate {
-                def installer = project.tasks.install.repositories.mavenInstaller
-                def deployer = project.tasks.uploadArchives.repositories.mavenDeployer
+                def installers = project.tasks.install.repositories
+                def deployers = project.tasks.uploadArchives.repositories
 
-                [installer, deployer]*.pom*.whenConfigured { pom ->
+                installers.plus(deployers)*.pom*.whenConfigured { pom ->
                     project.ext.optionalDeps.each { optionalDep ->
                         pom.dependencies.find {
                             dep -> dep.groupId == optionalDep.group && dep.artifactId == optionalDep.name


### PR DESCRIPTION
Somehow in my setup (not sure how), I end up with a second repository in install. The first one seems to be a dummy, and the second is what matters. However, with the current code, only the dummy one gets optional configuration.

This is easy to fix, and makes sense since technically both install and uploadArchives can have multiple repositories.

I would like to add a test, but it didn't seem immediately obvious how to modify the existing test for maven plugin, since it relies on the local .m2 cache...