### PR TITLE
Make tests work correctly on Windows

### DIFF
--- a/src/test/groovy/nebula/plugin/extraconfigurations/OptionalBasePluginIntegrationTest.groovy
+++ b/src/test/groovy/nebula/plugin/extraconfigurations/OptionalBasePluginIntegrationTest.groovy
@@ -37,7 +37,7 @@ apply plugin: 'nebula.optional-base'
         when:
         buildFile << """
 repositories {
-    maven { url '$mavenRepoDir.canonicalPath' }
+    maven { url '${mavenRepoDir.toURI().toURL()}' }
 }
 
 dependencies {
@@ -47,7 +47,7 @@ dependencies {
         ExecutionResult result = runTasksSuccessfully('dependencies')
 
         then:
-        result.standardOutput.contains("""
+        result.standardOutput.readLines().join('\n').contains("""
 compile - Dependencies for source set 'main'.
 \\--- foo:bar:2.4
      \\--- custom:baz:5.1.27
@@ -101,7 +101,7 @@ ext.excludeOptional = { dep ->
 }
 
 repositories {
-    maven { url '$mavenRepoDir.canonicalPath' }
+    maven { url '${mavenRepoDir.toURI().toURL()}' }
 }
 
 dependencies {
@@ -111,7 +111,7 @@ dependencies {
         ExecutionResult result = runTasksSuccessfully('dependencies')
 
         then:
-        result.standardOutput.contains("""
+        result.standardOutput.readLines().join('\n').contains("""
 compile - Dependencies for source set 'main'.
 \\--- foo:bar:2.4
 
@@ -170,7 +170,7 @@ publishing {
 
     repositories {
         maven {
-            url '$repoUrl.canonicalPath'
+            url '${repoUrl.toURI().toURL()}'
         }
     }
 }
@@ -203,7 +203,7 @@ dependencies {
 uploadArchives {
     repositories {
         mavenDeployer {
-            repository(url: 'file://$repoUrl.canonicalPath')
+            repository(url: '${repoUrl.toURI().toURL()}')
         }
     }
 }
@@ -243,7 +243,7 @@ publishing {
 
     repositories {
         ivy {
-            url '$repoUrl.canonicalPath'
+            url '${repoUrl.toURI().toURL()}'
         }
     }
 }
@@ -266,7 +266,7 @@ publishing {
             group = '$GROUP_ID'
             version = '$VERSION'
 
-            repositories { maven { url '${mavenRepo.absolutePath}' } }
+            repositories { maven { url '${mavenRepo.toURI().toURL()}' } }
 
             dependencies {
                 compile 'test.nebula:foo:1.0.0', optional
@@ -277,7 +277,7 @@ publishing {
                     repositories {
                         maven {
                             name 'testRepo'
-                            url '${repoUrl.canonicalPath}'
+                            url '${repoUrl.toURI().toURL()}'
                         }
                     }
                     publications {

--- a/src/test/groovy/nebula/plugin/extraconfigurations/ProvidedBasePluginIntegrationTest.groovy
+++ b/src/test/groovy/nebula/plugin/extraconfigurations/ProvidedBasePluginIntegrationTest.groovy
@@ -170,7 +170,7 @@ publishing {
 
     repositories {
         maven {
-            url '$repoUrl.canonicalPath'
+            url '${repoUrl.toURI().toURL()}'
         }
     }
 }
@@ -202,7 +202,7 @@ dependencies {
 
 uploadArchives {
     repositories.mavenDeployer {
-        repository(url: "file://$repoUrl.absolutePath")
+        repository(url: "${repoUrl.toURI().toURL()}")
     }
 }
 """
@@ -242,7 +242,7 @@ publishing {
 
     repositories {
         ivy {
-            url '$repoUrl.canonicalPath'
+            url '${repoUrl.toURI().toURL()}'
         }
     }
 }
@@ -359,7 +359,7 @@ task explodedWar(type: Copy) {
             group = '$GROUP_ID'
             version = '$VERSION'
 
-            repositories { maven { url '${mavenRepo.absolutePath}' } }
+            repositories { maven { url '${mavenRepo.toURI().toURL()}' } }
 
             dependencies {
                 provided 'test.nebula:foo:1.0.0'
@@ -370,7 +370,7 @@ task explodedWar(type: Copy) {
                     repositories {
                         maven {
                             name 'testRepo'
-                            url '${repoUrl.canonicalPath}'
+                            url '${repoUrl.toURI().toURL()}'
                         }
                     }
                     publications {


### PR DESCRIPTION
The tests dod not work correctly on Windows.
This has two reasons:
1. Paths are not correctly transformed to URLs which works fine on *nix-like systems, but not on Windows.
2. The nebula-test package is not Windows compatible.
3. Is fixed by the PR
4. Is fixed by PR nebula-plugins/nebula-test#64, so to fix this issue completely, the nebula-core/common.gradle file needs to be updated with a nebula-test version that has PR nebula-plugins/nebula-test#64 included and then this new common.gradle needs to be referenced from build.gradle of this project.
