### PR TITLE
Support projects with multiple poms.

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.5-rc-2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.5-bin.zip

--- a/src/main/groovy/nebula/plugin/extraconfigurations/OptionalBasePlugin.groovy
+++ b/src/main/groovy/nebula/plugin/extraconfigurations/OptionalBasePlugin.groovy
@@ -123,7 +123,7 @@ class OptionalBasePlugin implements Plugin<Project> {
                 def installers = project.tasks.install.repositories
                 def deployers = project.tasks.uploadArchives.repositories
 
-                installers.plus(deployers)*.pom*.whenConfigured { pom ->
+                (installers + deployers)*.activePomFilters*.pomTemplate*.whenConfigured { pom ->
                     project.ext.optionalDeps.each { optionalDep ->
                         pom.dependencies.find {
                             dep -> dep.groupId == optionalDep.group && dep.artifactId == optionalDep.name

--- a/src/main/groovy/nebula/plugin/extraconfigurations/OptionalBasePlugin.groovy
+++ b/src/main/groovy/nebula/plugin/extraconfigurations/OptionalBasePlugin.groovy
@@ -123,7 +123,7 @@ class OptionalBasePlugin implements Plugin<Project> {
                 def installers = project.tasks.install.repositories
                 def deployers = project.tasks.uploadArchives.repositories
 
-                (installers + deployers)*.activePomFilters*.pomTemplate*.whenConfigured { pom ->
+                (installers + deployers)*.activePomFilters.flatten()*.pomTemplate*.whenConfigured { pom ->
                     project.ext.optionalDeps.each { optionalDep ->
                         pom.dependencies.find {
                             dep -> dep.groupId == optionalDep.group && dep.artifactId == optionalDep.name


### PR DESCRIPTION
Apparently, getPom() always uses the default, but the default is not used if any filters are added.
Instead of asking for the one and only default pom, get the pom from the activePomFilters.